### PR TITLE
Add self-play training and table loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # Chess Engine
+
+This project contains a simple chess engine written in C++. Piece-square tables
+control much of the evaluation. A training script is provided to experiment with
+optimising these tables through self‑play.
+
+## Training piece-square tables
+
+The `training/train_pcsq.py` script performs a very basic self-play search over
+positions defined in `Chess Engine.cpp`. It mutates the piece-square tables and
+keeps any mutation that performs better than the current tables.
+
+Run the training script from the repository root:
+
+```bash
+python3 training/train_pcsq.py
+```
+
+When finished, a file called `pcsq_tables.json` is created in the current
+directory containing the optimised values.
+
+## Loading custom tables
+
+`engine.cpp` and `engine2.cpp` now include a helper function
+`loadPieceSquareTables(const std::string&)` which loads the piece-square arrays
+from a JSON file with the same format produced by the training script. Call this
+function once at start-up before searching moves:
+
+```cpp
+loadPieceSquareTables("pcsq_tables.json");
+```
+
+If loading fails, the built-in default tables are used.

--- a/engine.cpp
+++ b/engine.cpp
@@ -1,10 +1,12 @@
 #include "engine.h"
 #include <iostream>
+#include <fstream>
+#include <sstream>
 #include <chrono>
 
 std::chrono::time_point<std::chrono::high_resolution_clock> endTime;
 
-const int64_t pawn_pcsq[64] = {
+int64_t pawn_pcsq[64] = {
       0,   0,   0,   0,   0,   0,   0,   0,
      15,  20,  30,  40,  40,  30,  20,  15,
      10,  10,  20,  30,  30,  20,  10,  10,
@@ -15,7 +17,7 @@ const int64_t pawn_pcsq[64] = {
       0,   0,   0,   0,   0,   0,   0,   0
 };
 
-const int64_t knight_pcsq[64] = {
+int64_t knight_pcsq[64] = {
     -50, -40, -30, -30, -30, -30, -40, -50,
     -40, -20,   0,   0,   0,   0, -20, -40,
     -30,   0,  10,  15,  15,  10,   0, -30,
@@ -26,7 +28,7 @@ const int64_t knight_pcsq[64] = {
     -50, -40, -30, -30, -30, -30, -40, -50
 };
 
-const int64_t bishop_pcsq[64] = {
+int64_t bishop_pcsq[64] = {
     -10, -10, -10, -10, -10, -10, -10, -10,
     -10,   0,   0,   0,   0,   0,   0, -10,
     -10,   0,   5,   5,   5,   5,   0, -10,
@@ -37,7 +39,7 @@ const int64_t bishop_pcsq[64] = {
     -10, -10, -20, -10, -10, -20, -10, -10
 };
 
-const int64_t king_pcsq[64] = {
+int64_t king_pcsq[64] = {
     -40, -40, -40, -40, -40, -40, -40, -40,
     -40, -40, -40, -40, -40, -40, -40, -40,
     -40, -40, -40, -40, -40, -40, -40, -40,
@@ -48,7 +50,7 @@ const int64_t king_pcsq[64] = {
       0,  20,  40, -20,   0, -20,  40,  20
 };
 
-const int64_t king_pcsq_black[64] = {
+int64_t king_pcsq_black[64] = {
     -40, -40, -40, -40, -40, -40, -40, -40,
     -40, -40, -40, -40, -40, -40, -40, -40,
     -40, -40, -40, -40, -40, -40, -40, -40,
@@ -59,7 +61,7 @@ const int64_t king_pcsq_black[64] = {
      20,  40, -20,   0, -20,  40,  20,   0  
 };
 
-const int64_t king_endgame_pcsq[64] = {
+int64_t king_endgame_pcsq[64] = {
     -40, -30, -20, -10, -10, -20, -30, -40,
     -30, -10,   0,  10,  10,   0, -10, -30,
     -20,   0,  30,  50,  50,  30,   0, -20,
@@ -69,6 +71,26 @@ const int64_t king_endgame_pcsq[64] = {
     -30, -10,   0,  10,  10,   0, -10, -30,
     -40, -30, -20, -10, -10, -20, -30, -40
 };
+bool loadPieceSquareTables(const std::string& file) {
+    std::ifstream in(file);
+    if(!in) return false;
+    std::string data((std::istreambuf_iterator<char>(in)), {});
+    auto parse = [&](const std::string& key, int64_t* arr) {
+        size_t p = data.find("\"" + key + "\"");
+        if(p == std::string::npos) return;
+        p = data.find('[', p);
+        size_t e = data.find(']', p);
+        std::istringstream ss(data.substr(p+1, e - p - 1));
+        for(int i=0;i<64;i++) ss >> arr[i];
+    };
+    parse("pawn_pcsq", pawn_pcsq);
+    parse("knight_pcsq", knight_pcsq);
+    parse("bishop_pcsq", bishop_pcsq);
+    parse("king_pcsq", king_pcsq);
+    parse("king_pcsq_black", king_pcsq_black);
+    parse("king_endgame_pcsq", king_endgame_pcsq);
+    return true;
+}
 
 unsigned int ctzll2(unsigned long long x) {
     unsigned long index; // Variable to store the result
@@ -165,7 +187,7 @@ double_t evaluate(Board& board) {
     double_t gamePhase = ((totalMaterial - currentMaterial)) / totalMaterial;
 
     // Helper function to get the positional value of a bitboard
-    auto getPositionalValueWhite = [](int64_t pieces, const int64_t values[]) {
+    auto getPositionalValueWhite = [](int64_t pieces, int64_t values[]) {
         double_t positionalValue = 0;
         while (pieces) {
             int index = ctzll2(pieces);
@@ -176,7 +198,7 @@ double_t evaluate(Board& board) {
         };
 
     // Helper function to get the positional value of a bitboard
-    auto getPositionalValueBlack = [](int64_t pieces, const int64_t values[]) {
+    auto getPositionalValueBlack = [](int64_t pieces, int64_t values[]) {
         double_t positionalValue = 0;
         while (pieces) {
             int index = ctzll2(pieces);

--- a/engine2.cpp
+++ b/engine2.cpp
@@ -1,6 +1,8 @@
 #include "engine.h"
 #include <iostream>
 #include <chrono>
+#include <fstream>
+#include <sstream>
 #include "engine2.h"
 #include <vector>
 #include <algorithm>
@@ -8,7 +10,7 @@
 
 std::chrono::time_point<std::chrono::high_resolution_clock> endTime2;
 
-const int64_t pawn_pcsq[64] = {
+int64_t pawn_pcsq[64] = {
       0,   0,   0,   0,   0,   0,   0,   0,
      15,  20,  30,  40,  40,  30,  20,  15,
      10,  10,  20,  30,  30,  20,  10,  10,
@@ -19,7 +21,7 @@ const int64_t pawn_pcsq[64] = {
       0,   0,   0,   0,   0,   0,   0,   0
 };
 
-const int64_t knight_pcsq[64] = {
+int64_t knight_pcsq[64] = {
     -50, -40, -30, -30, -30, -30, -40, -50,
     -40, -20,   0,   0,   0,   0, -20, -40,
     -30,   0,  10,  15,  15,  10,   0, -30,
@@ -30,7 +32,7 @@ const int64_t knight_pcsq[64] = {
     -50, -40, -30, -30, -30, -30, -40, -50
 };
 
-const int64_t bishop_pcsq[64] = {
+int64_t bishop_pcsq[64] = {
     -10, -10, -10, -10, -10, -10, -10, -10,
     -10,   0,   0,   0,   0,   0,   0, -10,
     -10,   0,   5,   5,   5,   5,   0, -10,
@@ -41,7 +43,7 @@ const int64_t bishop_pcsq[64] = {
     -10, -10, -20, -10, -10, -20, -10, -10
 };
 
-const int64_t king_pcsq[64] = {
+int64_t king_pcsq[64] = {
     -40, -40, -40, -40, -40, -40, -40, -40,
     -40, -40, -40, -40, -40, -40, -40, -40,
     -40, -40, -40, -40, -40, -40, -40, -40,
@@ -52,7 +54,7 @@ const int64_t king_pcsq[64] = {
       0,  20,  40, -20,   0, -20,  40,  20
 };
 
-const int64_t king_pcsq_black[64] = {
+int64_t king_pcsq_black[64] = {
     -40, -40, -40, -40, -40, -40, -40, -40,
     -40, -40, -40, -40, -40, -40, -40, -40,
     -40, -40, -40, -40, -40, -40, -40, -40,
@@ -63,7 +65,7 @@ const int64_t king_pcsq_black[64] = {
      20,  40, -20,   0, -20,  40,  20,   0 
 };
 
-const int64_t king_endgame_pcsq[64] = {
+int64_t king_endgame_pcsq[64] = {
     -40, -30, -20, -10, -10, -20, -30, -40,
     -30, -10,   0,  10,  10,   0, -10, -30,
     -20,   0,  30,  50,  50,  30,   0, -20,
@@ -74,6 +76,26 @@ const int64_t king_endgame_pcsq[64] = {
     -40, -30, -20, -10, -10, -20, -30, -40
 };
 
+bool loadPieceSquareTables(const std::string& file) {
+    std::ifstream in(file);
+    if(!in) return false;
+    std::string data((std::istreambuf_iterator<char>(in)), {});
+    auto parse = [&](const std::string& key, int64_t* arr) {
+        size_t p = data.find("\"" + key + "\"");
+        if(p == std::string::npos) return;
+        p = data.find('[', p);
+        size_t e = data.find(']', p);
+        std::istringstream ss(data.substr(p+1, e - p - 1));
+        for(int i=0;i<64;i++) ss >> arr[i];
+    };
+    parse("pawn_pcsq", pawn_pcsq);
+    parse("knight_pcsq", knight_pcsq);
+    parse("bishop_pcsq", bishop_pcsq);
+    parse("king_pcsq", king_pcsq);
+    parse("king_pcsq_black", king_pcsq_black);
+    parse("king_endgame_pcsq", king_endgame_pcsq);
+    return true;
+}
 unsigned int ctzll3(unsigned long long x) {
     unsigned long index; // Variable to store the result
     // _BitScanForward64 returns 0 if x is zero, so handle this case:
@@ -183,7 +205,7 @@ double_t evaluate2(Board& board) {
     double_t gamePhase = ((totalMaterial - currentMaterial)) / totalMaterial;
 
     // Helper function to get the positional value of a bitboard
-    auto getPositionalValueWhite = [](int64_t pieces, const int64_t values[]) {
+    auto getPositionalValueWhite = [](int64_t pieces, int64_t values[]) {
         double_t positionalValue = 0;
         while (pieces) {
             int index = ctzll3(pieces);
@@ -194,7 +216,7 @@ double_t evaluate2(Board& board) {
         };
 
     // Helper function to get the positional value of a bitboard
-    auto getPositionalValueBlack = [](int64_t pieces, const int64_t values[]) {
+    auto getPositionalValueBlack = [](int64_t pieces, int64_t values[]) {
         double_t positionalValue = 0;
         while (pieces) {
             int index = ctzll3(pieces);

--- a/training/train_pcsq.py
+++ b/training/train_pcsq.py
@@ -1,0 +1,245 @@
+import json
+import random
+import re
+
+
+def load_fens():
+    with open('Chess Engine.cpp', 'r') as f:
+        text = f.read()
+    m = re.search(r"const char\* fenArray\[] = \{([^}]*)\};", text, re.S)
+    return re.findall(r"\"([^\"]+)\"", m.group(1)) if m else []
+
+
+def load_default_tables():
+    arrays = [
+        'pawn_pcsq',
+        'knight_pcsq',
+        'bishop_pcsq',
+        'king_pcsq',
+        'king_pcsq_black',
+        'king_endgame_pcsq'
+    ]
+    tables = {}
+    with open('engine.cpp', 'r') as f:
+        text = f.read()
+    for name in arrays:
+        m = re.search(rf"{name}\s*\[64\]\s*=\s*\{{([^}}]+)\}};", text, re.S)
+        if not m:
+            continue
+        nums = [int(x) for x in re.findall(r'-?\d+', m.group(1))]
+        tables[name] = nums
+    return tables
+
+
+# Board helpers
+
+def parse_fen(fen):
+    parts = fen.split()
+    rows = parts[0].split('/')
+    board = []
+    for r in rows:
+        row = []
+        for c in r:
+            if c.isdigit():
+                row.extend(['.'] * int(c))
+            else:
+                row.append(c)
+        board.append(row)
+    turn = parts[1]
+    return board, turn
+
+
+def to_index(row, col):
+    return (7 - row) * 8 + col
+
+
+def is_white(piece):
+    return piece.isupper()
+
+
+def generate_moves(board, turn):
+    moves = []
+    dirs_knight = [(2,1),(1,2),(-1,2),(-2,1),(-2,-1),(-1,-2),(1,-2),(2,-1)]
+    dirs_bishop = [(1,1),(1,-1),(-1,1),(-1,-1)]
+    dirs_rook = [(1,0),(-1,0),(0,1),(0,-1)]
+    dirs_king = dirs_bishop + dirs_rook
+    for r in range(8):
+        for c in range(8):
+            p = board[r][c]
+            if p == '.':
+                continue
+            if turn == 'w' and not is_white(p):
+                continue
+            if turn == 'b' and is_white(p):
+                continue
+            if p in 'Pp':
+                direction = -1 if p == 'P' else 1
+                start_row = 6 if p == 'P' else 1
+                nr = r + direction
+                if 0 <= nr < 8:
+                    if board[nr][c] == '.':
+                        moves.append(((r,c),(nr,c)))
+                        if r == start_row and board[nr + direction][c] == '.' and board[nr][c] == '.':
+                            moves.append(((r,c),(nr + direction,c)))
+                    for dc in (-1,1):
+                        nc = c + dc
+                        if 0 <= nc < 8:
+                            target = board[nr][nc]
+                            if target != '.' and is_white(target) != is_white(p):
+                                moves.append(((r,c),(nr,nc)))
+            elif p in 'Nn':
+                for dr,dc in dirs_knight:
+                    nr, nc = r+dr, c+dc
+                    if 0<=nr<8 and 0<=nc<8:
+                        target = board[nr][nc]
+                        if target == '.' or is_white(target) != is_white(p):
+                            moves.append(((r,c),(nr,nc)))
+            elif p in 'Bb':
+                for dr,dc in dirs_bishop:
+                    nr,nc=r+dr,c+dc
+                    while 0<=nr<8 and 0<=nc<8:
+                        target=board[nr][nc]
+                        if target=='.':
+                            moves.append(((r,c),(nr,nc)))
+                        else:
+                            if is_white(target)!=is_white(p):
+                                moves.append(((r,c),(nr,nc)))
+                            break
+                        nr+=dr
+                        nc+=dc
+            elif p in 'Rr':
+                for dr,dc in dirs_rook:
+                    nr,nc=r+dr,c+dc
+                    while 0<=nr<8 and 0<=nc<8:
+                        target=board[nr][nc]
+                        if target=='.':
+                            moves.append(((r,c),(nr,nc)))
+                        else:
+                            if is_white(target)!=is_white(p):
+                                moves.append(((r,c),(nr,nc)))
+                            break
+                        nr+=dr
+                        nc+=dc
+            elif p in 'Qq':
+                for dr,dc in dirs_bishop+dirs_rook:
+                    nr,nc=r+dr,c+dc
+                    while 0<=nr<8 and 0<=nc<8:
+                        target=board[nr][nc]
+                        if target=='.':
+                            moves.append(((r,c),(nr,nc)))
+                        else:
+                            if is_white(target)!=is_white(p):
+                                moves.append(((r,c),(nr,nc)))
+                            break
+                        nr+=dr
+                        nc+=dc
+            elif p in 'Kk':
+                for dr,dc in dirs_king:
+                    nr,nc=r+dr,c+dc
+                    if 0<=nr<8 and 0<=nc<8:
+                        target=board[nr][nc]
+                        if target=='.' or is_white(target)!=is_white(p):
+                            moves.append(((r,c),(nr,nc)))
+    return moves
+
+
+def make_move(board, move):
+    (r1,c1),(r2,c2) = move
+    new = [row[:] for row in board]
+    new[r2][c2] = new[r1][c1]
+    new[r1][c1] = '.'
+    return new
+
+
+def evaluate(board, tables):
+    score = 0
+    for r in range(8):
+        for c in range(8):
+            p = board[r][c]
+            if p == '.':
+                continue
+            idx = to_index(r,c)
+            if p.isupper():
+                if p == 'P':
+                    score += tables['pawn_pcsq'][63-idx] + 100
+                elif p == 'N':
+                    score += tables['knight_pcsq'][63-idx] + 320
+                elif p == 'B':
+                    score += tables['bishop_pcsq'][63-idx] + 330
+                elif p == 'R':
+                    score += 500
+                elif p == 'Q':
+                    score += 900
+                elif p == 'K':
+                    score += tables['king_pcsq'][63-idx]
+            else:
+                if p == 'p':
+                    score -= tables['pawn_pcsq'][idx] + 100
+                elif p == 'n':
+                    score -= tables['knight_pcsq'][idx] + 320
+                elif p == 'b':
+                    score -= tables['bishop_pcsq'][idx] + 330
+                elif p == 'r':
+                    score -= 500
+                elif p == 'q':
+                    score -= 900
+                elif p == 'k':
+                    score -= tables['king_pcsq_black'][idx]
+    return score
+
+
+def play_game(fen, tables, limit=40):
+    board, turn = parse_fen(fen)
+    for _ in range(limit):
+        moves = generate_moves(board, turn)
+        if not moves:
+            return 1 if turn == 'b' else -1
+        best = None
+        best_score = -1e9 if turn == 'w' else 1e9
+        for mv in moves:
+            nb = make_move(board, mv)
+            sc = evaluate(nb, tables)
+            if turn == 'w':
+                if sc > best_score:
+                    best_score = sc
+                    best = mv
+            else:
+                if sc < best_score:
+                    best_score = sc
+                    best = mv
+        board = make_move(board, best)
+        turn = 'b' if turn == 'w' else 'w'
+    return 0
+
+
+def selfplay_score(tables, games=5):
+    fens = load_fens()[:games]
+    score = 0
+    for fen in fens:
+        score += play_game(fen, tables)
+    return score
+
+
+def mutate(tables, step=5):
+    new = {}
+    for k,v in tables.items():
+        new[k] = [x + random.randint(-step, step) for x in v]
+    return new
+
+
+def train(iterations=10, games=5):
+    tables = load_default_tables()
+    best = selfplay_score(tables, games)
+    for i in range(iterations):
+        cand = mutate(tables)
+        score = selfplay_score(cand, games)
+        if score > best:
+            tables, best = cand, score
+            print(f'Improved to {best} at iteration {i}')
+    with open('pcsq_tables.json', 'w') as f:
+        json.dump(tables, f, indent=2)
+    print('Saved tables to pcsq_tables.json')
+
+
+if __name__ == '__main__':
+    train()


### PR DESCRIPTION
## Summary
- add a `training` folder with `train_pcsq.py`
- allow loading piece-square tables from JSON
- document training and loading in `README.md`

## Testing
- `python3 -m py_compile training/train_pcsq.py`
